### PR TITLE
Migrate free disk space workflow setting

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-azure:
-  free_disk_space: true
 build_platform:
   linux_aarch64: linux_64
 conda_build:
@@ -10,3 +8,7 @@ github:
   tooling_branch_name: main
 provider:
   linux_aarch64: azure
+workflow_settings:
+  free_disk_space:
+    - provider: azure
+      value: quick


### PR DESCRIPTION
Replace deprecated `azure.free_disk_space` with the equivalent provider-scoped `workflow_settings.free_disk_space` setting.

This preserves the existing Azure-only `quick` cleanup behavior and addresses the conda-smithy hint from #40.
